### PR TITLE
fix(actions): Add write permissions to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Adds `permissions: contents: write` to the release job to allow the `softprops/action-gh-release` action to upload assets to the GitHub Release.

This fixes the 'Resource not accessible by integration' error.