### PR TITLE
feat: Add LLM selection and custom system prompt

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -6,7 +6,8 @@ function plugin_openrouter_install() {
     \Config::setConfigurationValues('plugin:openrouter', [
         'openrouter_api_key' => '',
         'openrouter_model_name' => '',
-        'openrouter_bot_user_id' => 2
+        'openrouter_bot_user_id' => 2,
+        'openrouter_system_prompt' => ''
     ]);
     return true;
 }
@@ -26,6 +27,7 @@ function plugin_openrouter_item_add($item) {
     $api_key = $config['openrouter_api_key'] ?? '';
     $model_name = $config['openrouter_model_name'] ?? '';
     $bot_user_id = $config['openrouter_bot_user_id'] ?? 0;
+    $system_prompt_config = $config['openrouter_system_prompt'] ?? '';
 
     if (empty($api_key) || empty($model_name) || empty($bot_user_id)) {
         return;
@@ -42,6 +44,10 @@ function plugin_openrouter_item_add($item) {
     }
 
     $system_prompt = "You are an AI assistant acting as a Level 1 IT support technician for the company. Your name is 'OpenRouter Bot'. You must be professional and courteous in all your responses. Your primary goal is to resolve common user issues based on the provided ticket information.\n\nWhen responding to a user, please follow these guidelines:\n1.  Analyze the user's request carefully.\n2.  If the request is clear and you can provide a solution, offer a step-by-step guide.\n3.  If the request is unclear, ask for more information. Be specific about what you need.\n4.  If the issue is complex or requires administrative privileges you don't have, you must escalate the ticket. To do so, respond with the following exact phrase and nothing else: 'I am unable to resolve this issue and have escalated it to a system administrator.'\n5.  Do not invent solutions or provide information you are not sure about.\n6.  Always sign your responses with your name, 'OpenRouter Bot'.";
+
+    if (!empty($system_prompt_config)) {
+        $system_prompt = $system_prompt_config;
+    }
 
     $ch = curl_init();
     curl_setopt($ch, CURLOPT_URL, "https://openrouter.ai/api/v1/chat/completions");

--- a/openrouter.xml
+++ b/openrouter.xml
@@ -23,7 +23,7 @@
    </authors>
    <versions>
       <version>
-         <num>1.0.0</num>
+         <num>1.0.1</num>
          <compatibility>~10.0.0</compatibility>
       </version>
    </versions>

--- a/src/Config.php
+++ b/src/Config.php
@@ -51,10 +51,26 @@ class Config extends \Config
 
         $current_config = self::getConfig();
         $canedit        = Session::haveRight(self::$rightname, UPDATE);
+        $models         = self::getModels();
 
         TemplateRenderer::getInstance()->display('@openrouter/config.html.twig', [
             'current_config' => $current_config,
-            'can_edit'       => $canedit
+            'can_edit'       => $canedit,
+            'models'         => $models
         ]);
+    }
+
+    static function getModels() {
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, "https://openrouter.ai/api/v1/models");
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        $result = curl_exec($ch);
+        curl_close($ch);
+
+        $response = json_decode($result, true);
+        if (isset($response['data'])) {
+            return $response['data'];
+        }
+        return [];
     }
 }

--- a/templates/config.html.twig
+++ b/templates/config.html.twig
@@ -2,7 +2,7 @@
 
 {% if can_edit %}
     <form name="form" action="{{ "Config"|itemtype_form_path }}" method="POST">
-        <input type="hidden" name="config_class" value="GlpiPlugin\\Openrouter\\Config">
+        <input type="hidden" name="config_class" value="GlpiPlugin\Openrouter\Config">
         <input type="hidden" name="config_context" value="plugin:openrouter">
         <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}">
 
@@ -12,10 +12,22 @@
             __('OpenRouter API Key', 'openrouter')
         ) }}
 
-        {{ fields.textField(
+        {% set model_items = {} %}
+        {% for model in models %}
+            {% set model_items = model_items|merge({(model.id): model.name}) %}
+        {% endfor %}
+
+        {{ fields.dropdown(
             'openrouter_model_name',
+            model_items,
             current_config['openrouter_model_name'],
             __('OpenRouter Model Name', 'openrouter')
+        ) }}
+
+        {{ fields.textarea(
+            'openrouter_system_prompt',
+            current_config['openrouter_system_prompt'],
+            __('OpenRouter System Prompt', 'openrouter')
         ) }}
 
         {{ fields.numberField(


### PR DESCRIPTION
This commit introduces two new features for the OpenRouter plugin:

1.  **LLM Selection from a List:** The configuration page now fetches the list of available models directly from the OpenRouter API and displays them in a dropdown menu. This allows administrators to easily select a model without having to manually look up and type the model ID.

2.  **Customizable System Prompt:** A new text area has been added to the configuration page, allowing administrators to define a custom system prompt. If a custom prompt is provided, it will be used in the API requests to OpenRouter. If left empty, the plugin will use the original, hardcoded default prompt.

The plugin version has been updated to 1.0.1 to reflect these changes.