### PR TITLE
Fix: Make plugin compatible with GLPI 11

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -1,29 +1,35 @@
 <?php
 
+use Config;
+use GlpiPlugin\Openrouter\Config as OpenrouterConfig;
+use TicketFollowup;
 use Toolbox;
 
-function plugin_openrouter_install() {
-    \Config::setConfigurationValues('plugin:openrouter', [
-        'openrouter_api_key' => '',
-        'openrouter_model_name' => '',
+function plugin_openrouter_install()
+{
+    Config::setConfigurationValues('plugin:openrouter', [
+        'openrouter_api_key'     => '',
+        'openrouter_model_name'  => '',
         'openrouter_bot_user_id' => 2,
         'openrouter_system_prompt' => ''
     ]);
     return true;
 }
 
-function plugin_openrouter_uninstall() {
-    $config = new \Config();
+function plugin_openrouter_uninstall()
+{
+    $config = new Config();
     $config->deleteByCriteria(['context' => 'plugin:openrouter']);
     return true;
 }
 
-function plugin_openrouter_item_add($item) {
+function plugin_openrouter_item_add($item)
+{
     if (!in_array($item->getType(), ['Ticket', 'TicketFollowup'])) {
         return;
     }
 
-    $config = \GlpiPlugin\Openrouter\Config::getConfig();
+    $config = OpenrouterConfig::getConfig();
     $api_key = $config['openrouter_api_key'] ?? '';
     $model_name = $config['openrouter_model_name'] ?? '';
     $bot_user_id = $config['openrouter_bot_user_id'] ?? 0;
@@ -82,7 +88,7 @@ function plugin_openrouter_item_add($item) {
     $response_content = $response['choices'][0]['message']['content'] ?? '';
 
     if (!empty($response_content)) {
-        $followup = new \TicketFollowup();
+        $followup = new TicketFollowup();
         $followup_data = [
             'tickets_id' => ($item->getType() === 'Ticket') ? $item->getID() : $item->fields['tickets_id'],
             'content' => $response_content . "\n\n<!-- openrouter_bot_response -->",

--- a/openrouter.xml
+++ b/openrouter.xml
@@ -23,8 +23,8 @@
    </authors>
    <versions>
       <version>
-         <num>1.0.1</num>
-         <compatibility>~10.0.0</compatibility>
+         <num>1.1.0</num>
+         <compatibility>~11.0.0</compatibility>
       </version>
    </versions>
    <langs>

--- a/setup.php
+++ b/setup.php
@@ -6,10 +6,10 @@ use Glpi\Plugin\Hooks;
 define('PLUGIN_OPENROUTER_VERSION', '1.0.0');
 
 // Minimal GLPI version, inclusive
-define("PLUGIN_OPENROUTER_MIN_GLPI_VERSION", "10.0.0");
+define("PLUGIN_OPENROUTER_MIN_GLPI_VERSION", "11.0.0");
 
 // Maximum GLPI version, exclusive
-define("PLUGIN_OPENROUTER_MAX_GLPI_VERSION", "10.0.99");
+define("PLUGIN_OPENROUTER_MAX_GLPI_VERSION", "11.1.0");
 
 function plugin_init_openrouter() {
    global $PLUGIN_HOOKS;

--- a/src/Config.php
+++ b/src/Config.php
@@ -3,10 +3,11 @@
 namespace GlpiPlugin\Openrouter;
 
 use CommonGLPI;
-use Session;
+use Config as GlpiConfig;
 use Glpi\Application\View\TemplateRenderer;
+use Session;
 
-class Config extends \Config
+class Config extends GlpiConfig
 {
 
     static function getTypeName($nb = 0)
@@ -16,16 +17,7 @@ class Config extends \Config
 
     static function getConfig()
     {
-        return \Config::getConfigurationValues('plugin:openrouter');
-    }
-
-    function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
-    {
-        switch ($item->getType()) {
-            case \Config::class:
-                return self::createTabEntry(self::getTypeName());
-        }
-        return '';
+        return GlpiConfig::getConfigurationValues('plugin:openrouter');
     }
 
     static function displayTabContentForItem(
@@ -33,17 +25,9 @@ class Config extends \Config
         $tabnum = 1,
         $withtemplate = 0
     ) {
-        switch ($item->getType()) {
-            case \Config::class:
-                self::showForConfig($item);
-                break;
+        if ($item->getType() != 'Config') {
+            return;
         }
-
-        return true;
-    }
-
-    static function showForConfig(\Config $config) {
-        global $CFG_GLPI;
 
         if (!self::canView()) {
             return false;
@@ -58,9 +42,12 @@ class Config extends \Config
             'can_edit'       => $canedit,
             'models'         => $models
         ]);
+
+        return true;
     }
 
-    static function getModels() {
+    static function getModels()
+    {
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, "https://openrouter.ai/api/v1/models");
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);


### PR DESCRIPTION
This commit updates the plugin to be compatible with GLPI version 11.0.0 and higher.

The main changes include:
- Updated min/max GLPI version in `setup.php`.
- Refactored `src/Config.php` to align with GLPI 11's new class structure for configuration tabs.
- Updated `hook.php` to use proper namespaces for GLPI core classes.
- Updated `openrouter.xml` with the new compatibility information and version number.

These changes address the fatal error that occurred when loading the plugin page in GLPI 11.