### PR TITLE
Feat: Add missing configuration tab

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -9,6 +9,13 @@ use Session;
 
 class Config extends GlpiConfig
 {
+    static function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
+    {
+        if ($item->getType() == 'Config') {
+            return self::getTypeName();
+        }
+        return '';
+    }
 
     static function getTypeName($nb = 0)
     {


### PR DESCRIPTION
This commit fixes an issue where the plugin's configuration tab was not appearing in the GLPI setup menu.

The problem was caused by the absence of the `getTabNameForItem` static method in the `GlpiPlugin\Openrouter\Config` class. This method is required by GLPI to retrieve the name of the tab to be displayed.

This change adds the `getTabNameForItem` method, which checks for the `Config` object type and returns the plugin's name. This allows GLPI to correctly render the configuration tab, making the plugin configurable through the user interface.