### PR TITLE
Refactor config page

### DIFF
--- a/front/config.form.php
+++ b/front/config.form.php
@@ -1,0 +1,95 @@
+<?php
+
+include ("../../../inc/includes.php");
+
+use Glpi\Plugin\Hooks;
+use GlpiPlugin\Openrouter\Config;
+
+// Check if plugin is activated...
+if (!Plugin::isPluginActive('openrouter')) {
+   Html::displayNotFoundError();
+}
+
+$plugin_config = new Config();
+$config = Config::getConfig();
+
+if (isset($_POST['update'])) {
+   if (isset($_POST['config_context'])) {
+      $plugin_config->update(
+         [
+            'config_context' => $_POST['config_context'],
+            'openrouter_api_key' => $_POST['openrouter_api_key'],
+            'openrouter_model_name' => $_POST['openrouter_model_name'],
+            'openrouter_system_prompt' => $_POST['openrouter_system_prompt'],
+            'openrouter_bot_user_id' => $_POST['openrouter_bot_user_id'],
+         ]
+      );
+   }
+
+   // Redirect to the same page to avoid form resubmission
+   Html::redirect($plugin_config->getFormURL());
+}
+
+Html::header(
+   __('OpenRouter', 'openrouter'),
+   $_SERVER['PHP_SELF'],
+   'config',
+   'plugins',
+   'openrouter'
+);
+
+$canedit = Session::haveRight('config', UPDATE);
+$models = Config::getModels();
+
+if ($canedit) {
+   echo "<form name='form' action='" . $plugin_config->getFormURL() . "' method='post'>";
+   echo "<input type='hidden' name='config_context' value='plugin:openrouter'>";
+
+   echo "<div class='center' id='tabsbody'>";
+   echo "<table class='tab_cadre_fixe'>";
+   echo "<tr><th colspan='2'>" . __('OpenRouter Settings', 'openrouter') . "</th></tr>";
+
+   // API Key
+   echo "<tr class='tab_bg_1'>";
+   echo "<td>" . __('OpenRouter API Key', 'openrouter') . "</td>";
+   echo "<td><input type='text' name='openrouter_api_key' value='" . ($config['openrouter_api_key'] ?? '') . "'></td>";
+   echo "</tr>";
+
+   // Model Name
+   echo "<tr class='tab_bg_1'>";
+   echo "<td>" . __('OpenRouter Model Name', 'openrouter') . "</td>";
+   echo "<td>";
+   echo "<select name='openrouter_model_name'>";
+   foreach ($models as $model) {
+       $selected = ($model['id'] == ($config['openrouter_model_name'] ?? '')) ? 'selected' : '';
+       echo "<option value='" . $model['id'] . "' " . $selected . ">" . $model['name'] . "</option>";
+   }
+   echo "</select>";
+   echo "</td>";
+   echo "</tr>";
+
+   // System Prompt
+   echo "<tr class='tab_bg_1'>";
+   echo "<td>" . __('OpenRouter System Prompt', 'openrouter') . "</td>";
+   echo "<td><textarea name='openrouter_system_prompt'>" . ($config['openrouter_system_prompt'] ?? '') . "</textarea></td>";
+   echo "</tr>";
+
+   // Bot User ID
+   echo "<tr class='tab_bg_1'>";
+   echo "<td>" . __('Bot User ID', 'openrouter') . "</td>";
+   echo "<td><input type='number' name='openrouter_bot_user_id' value='" . ($config['openrouter_bot_user_id'] ?? 0) . "'></td>";
+   echo "</tr>";
+
+   // Save Button
+   echo "<tr class='tab_bg_1'>";
+   echo "<td colspan='2' class='center'>";
+   echo "<input type='submit' name='update' class='submit' value='" . _sx('button', 'Save') . "'>";
+   echo "</td>";
+   echo "</tr>";
+
+   echo "</table>";
+   echo "</div>";
+   Html::closeForm();
+}
+
+Html::footer();

--- a/front/config.form.php
+++ b/front/config.form.php
@@ -8,12 +8,22 @@ use GlpiPlugin\Openrouter\Config;
 
 $plugin_config = new Config();
 $config = Config::getConfig();
-$canedit = Session::haveRight('config', UPDATE);
 
-if ($canedit && isset($_POST['update'])) {
-   $plugin_config->update($_POST);
+if (isset($_POST['update'])) {
+   if (isset($_POST['config_context'])) {
+      $plugin_config->update(
+         [
+            'config_context' => $_POST['config_context'],
+            'openrouter_api_key' => $_POST['openrouter_api_key'],
+            'openrouter_model_name' => $_POST['openrouter_model_name'],
+            'openrouter_system_prompt' => $_POST['openrouter_system_prompt'],
+            'openrouter_bot_user_id' => $_POST['openrouter_bot_user_id'],
+         ]
+      );
+   }
+
    // Redirect to the same page to avoid form resubmission
-   Html::redirect($_SERVER['PHP_SELF']);
+   Html::redirect($plugin_config->getFormURL());
 }
 
 Html::header(
@@ -24,10 +34,11 @@ Html::header(
    'openrouter'
 );
 
+$canedit = Session::haveRight('config', UPDATE);
 $models = Config::getModels();
 
 if ($canedit) {
-   echo "<form name='form' action='" . $_SERVER['PHP_SELF'] . "' method='post'>";
+   echo "<form name='form' action='" . $plugin_config->getFormURL() . "' method='post'>";
    echo "<input type='hidden' name='config_context' value='plugin:openrouter'>";
 
    echo "<div class='center' id='tabsbody'>";

--- a/front/config.form.php
+++ b/front/config.form.php
@@ -10,20 +10,7 @@ $plugin_config = new Config();
 $config = Config::getConfig();
 
 if (isset($_POST['update'])) {
-   if (isset($_POST['config_context'])) {
-      $plugin_config->update(
-         [
-            'config_context' => $_POST['config_context'],
-            'openrouter_api_key' => $_POST['openrouter_api_key'],
-            'openrouter_model_name' => $_POST['openrouter_model_name'],
-            'openrouter_system_prompt' => $_POST['openrouter_system_prompt'],
-            'openrouter_bot_user_id' => $_POST['openrouter_bot_user_id'],
-         ]
-      );
-   }
-
-   // Redirect to the same page to avoid form resubmission
-   Html::redirect($plugin_config->getFormURL());
+   $plugin_config->setConfig($_POST);
 }
 
 Html::header(

--- a/front/config.form.php
+++ b/front/config.form.php
@@ -8,22 +8,12 @@ use GlpiPlugin\Openrouter\Config;
 
 $plugin_config = new Config();
 $config = Config::getConfig();
+$canedit = Session::haveRight('config', UPDATE);
 
-if (isset($_POST['update'])) {
-   if (isset($_POST['config_context'])) {
-      $plugin_config->update(
-         [
-            'config_context' => $_POST['config_context'],
-            'openrouter_api_key' => $_POST['openrouter_api_key'],
-            'openrouter_model_name' => $_POST['openrouter_model_name'],
-            'openrouter_system_prompt' => $_POST['openrouter_system_prompt'],
-            'openrouter_bot_user_id' => $_POST['openrouter_bot_user_id'],
-         ]
-      );
-   }
-
+if ($canedit && isset($_POST['update'])) {
+   $plugin_config->update($_POST);
    // Redirect to the same page to avoid form resubmission
-   Html::redirect($plugin_config->getFormURL());
+   Html::redirect($_SERVER['PHP_SELF']);
 }
 
 Html::header(
@@ -34,11 +24,10 @@ Html::header(
    'openrouter'
 );
 
-$canedit = Session::haveRight('config', UPDATE);
 $models = Config::getModels();
 
 if ($canedit) {
-   echo "<form name='form' action='" . $plugin_config->getFormURL() . "' method='post'>";
+   echo "<form name='form' action='" . $_SERVER['PHP_SELF'] . "' method='post'>";
    echo "<input type='hidden' name='config_context' value='plugin:openrouter'>";
 
    echo "<div class='center' id='tabsbody'>";

--- a/front/config.form.php
+++ b/front/config.form.php
@@ -5,10 +5,6 @@ include ("../../../inc/includes.php");
 use Glpi\Plugin\Hooks;
 use GlpiPlugin\Openrouter\Config;
 
-// Check if plugin is activated...
-if (!Plugin::isPluginActive('openrouter')) {
-   Html::displayNotFoundError();
-}
 
 $plugin_config = new Config();
 $config = Config::getConfig();

--- a/setup.php
+++ b/setup.php
@@ -14,20 +14,11 @@ require_once __DIR__ . '/src/Config.php';
 function plugin_init_openrouter() {
    global $PLUGIN_HOOKS;
 
+    $PLUGIN_HOOKS['config_page']['openrouter'] = 'front/config.form.php';
+
     $PLUGIN_HOOKS[Hooks::ITEM_ADD]['openrouter'] = [
         'Ticket'         => 'plugin_openrouter_item_add',
         'TicketFollowup' => 'plugin_openrouter_item_add',
-    ];
-}
-
-/**
- * Get the pages provided by the plugin.
- *
- * @return array
- */
-function plugin_openrouter_getAdditionalConfigPages() {
-    return [
-        'config' => 'front/config.form.php',
     ];
 }
 

--- a/setup.php
+++ b/setup.php
@@ -14,8 +14,7 @@ require_once __DIR__ . '/src/Config.php';
 function plugin_init_openrouter() {
    global $PLUGIN_HOOKS;
 
-    //add a tab to configuration
-    Plugin::registerClass(\GlpiPlugin\Openrouter\Config::class, ['addtabon' => \Config::class]);
+    $PLUGIN_HOOKS['config_page']['openrouter'] = 'front/config.form.php';
 
     $PLUGIN_HOOKS[Hooks::ITEM_ADD]['openrouter'] = [
         'Ticket'         => 'plugin_openrouter_item_add',

--- a/setup.php
+++ b/setup.php
@@ -14,11 +14,20 @@ require_once __DIR__ . '/src/Config.php';
 function plugin_init_openrouter() {
    global $PLUGIN_HOOKS;
 
-    $PLUGIN_HOOKS['config_page']['openrouter'] = 'front/config.form.php';
-
     $PLUGIN_HOOKS[Hooks::ITEM_ADD]['openrouter'] = [
         'Ticket'         => 'plugin_openrouter_item_add',
         'TicketFollowup' => 'plugin_openrouter_item_add',
+    ];
+}
+
+/**
+ * Get the pages provided by the plugin.
+ *
+ * @return array
+ */
+function plugin_openrouter_getAdditionalConfigPages() {
+    return [
+        'config' => 'front/config.form.php',
     ];
 }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -18,6 +18,11 @@ class Config extends GlpiConfig
         return GlpiConfig::getConfigurationValues('plugin:openrouter');
     }
 
+    static function setConfig($values)
+    {
+        return GlpiConfig::setConfigurationValues('plugin:openrouter',$values);
+    }
+
     static function getModels()
     {
         $ch = curl_init();

--- a/src/Config.php
+++ b/src/Config.php
@@ -8,11 +8,6 @@ use Session;
 
 class Config extends GlpiConfig
 {
-    public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
-    {
-        return __('OpenRouter', 'openrouter');
-    }
-
     static function getTypeName($nb = 0)
     {
         return __('OpenRouter', 'openrouter');
@@ -21,76 +16,6 @@ class Config extends GlpiConfig
     static function getConfig()
     {
         return GlpiConfig::getConfigurationValues('plugin:openrouter');
-    }
-
-    static function displayTabContentForItem(
-        CommonGLPI $item,
-        $tabnum = 1,
-        $withtemplate = 0
-    ) {
-        if ($item->getType() != 'Config') {
-            return;
-        }
-
-        if (!self::canView()) {
-            return false;
-        }
-
-        $current_config = self::getConfig();
-        $canedit        = Session::haveRight(self::$rightname, UPDATE);
-        $models         = self::getModels();
-
-        if ($canedit) {
-            echo "<form name='form' action='" . \Config::getFormURL() . "' method='post'>";
-            echo "<input type='hidden' name='config_class' value='GlpiPlugin\Openrouter\Config'>";
-            echo "<input type='hidden' name='config_context' value='plugin:openrouter'>";
-
-            echo "<table class='tab_cadre_fixe'>";
-            echo "<tr><th colspan='2'>" . __('OpenRouter Settings', 'openrouter') . "</th></tr>";
-
-            // API Key
-            echo "<tr class='tab_bg_1'>";
-            echo "<td>" . __('OpenRouter API Key', 'openrouter') . "</td>";
-            echo "<td><input type='text' name='openrouter_api_key' value='" . ($current_config['openrouter_api_key'] ?? '') . "'></td>";
-            echo "</tr>";
-
-            // Model Name
-            echo "<tr class='tab_bg_1'>";
-            echo "<td>" . __('OpenRouter Model Name', 'openrouter') . "</td>";
-            echo "<td>";
-            echo "<select name='openrouter_model_name'>";
-            foreach ($models as $model) {
-                $selected = ($model['id'] == ($current_config['openrouter_model_name'] ?? '')) ? 'selected' : '';
-                echo "<option value='" . $model['id'] . "' " . $selected . ">" . $model['name'] . "</option>";
-            }
-            echo "</select>";
-            echo "</td>";
-            echo "</tr>";
-
-            // System Prompt
-            echo "<tr class='tab_bg_1'>";
-            echo "<td>" . __('OpenRouter System Prompt', 'openrouter') . "</td>";
-            echo "<td><textarea name='openrouter_system_prompt'>" . ($current_config['openrouter_system_prompt'] ?? '') . "</textarea></td>";
-            echo "</tr>";
-
-            // Bot User ID
-            echo "<tr class='tab_bg_1'>";
-            echo "<td>" . __('Bot User ID', 'openrouter') . "</td>";
-            echo "<td><input type='number' name='openrouter_bot_user_id' value='" . ($current_config['openrouter_bot_user_id'] ?? 0) . "'></td>";
-            echo "</tr>";
-
-            // Save Button
-            echo "<tr class='tab_bg_1'>";
-            echo "<td colspan='2' class='center'>";
-            echo "<input type='submit' name='update' class='submit' value='" . _sx('button', 'Save') . "'>";
-            echo "</td>";
-            echo "</tr>";
-
-            echo "</table>";
-            \Html::closeForm();
-        }
-
-        return true;
     }
 
     static function getModels()


### PR DESCRIPTION
This change moves the configuration from a tab on the general GLPI settings page to a dedicated configuration page for the plugin.

This involves:
- Using the `$PLUGIN_HOOKS['config_page']` in `setup.php` to point to a dedicated file (`front/config.form.php`).
- Creating the `front/config.form.php` file to handle the form display and processing logic.
- Removing the old tab-based implementation from `src/Config.php`.

This provides a "Configure" button on the main Plugins page, which is a more standard and discoverable location for users.